### PR TITLE
use exec to run supervisord

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -9,4 +9,5 @@ then
 	echo 1 > /firstrun
 fi
 
-/usr/local/bin/supervisord -c /etc/supervisord.conf
+exec /usr/local/bin/supervisord -c /etc/supervisord.conf
+


### PR DESCRIPTION
After looking into why the image was taking a while to shut down after `docker stop`, found articles (such as [here](https://docs.docker.com/reference/builder/) and [here](http://www.projectatomic.io/docs/docker-image-author-guidance/)) indicating that wrapper scripts should call their executable using `exec`, as this will cause that executable to run as PID 1 and correctly receive signals.

Otherwise supervisord never gets the signal and eventually will be `kill -9`ed, causing unclean shutdown.