### PR TITLE
Improvements to mail configuration, addition of a configuration volume, and SSH key generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,9 @@ RUN sed -i 's/\/usr\/sbin\/sendmail/\/usr\/bin\/msmtp/g' /etc/backuppc/config.pl
 
 RUN chmod 0755 /run.sh
 
+RUN tar -zf /root/etc-backuppc.tgz -C /etc/backuppc -c .
+
 EXPOSE 80
+VOLUME ["/etc/backuppc"]
 
 CMD ["/run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get install -y backuppc apache2-utils
 RUN htpasswd -b /etc/backuppc/htpasswd backuppc password
 
 COPY supervisord.conf /etc/supervisord.conf
-COPY msmtprc /var/lib/backuppc/.msmtprc
+COPY msmtprc /var/lib/backuppc/.msmtprc.dist
 COPY run.sh /run.sh
 COPY ssh-config /etc/backuppc-ssh-config
 
@@ -28,6 +28,9 @@ RUN sed -i 's/\/usr\/sbin\/sendmail/\/usr\/bin\/msmtp/g' /etc/backuppc/config.pl
 RUN chmod 0755 /run.sh
 
 RUN tar -zf /root/etc-backuppc.tgz -C /etc/backuppc -c .
+
+ENV MAILHOST mail
+ENV FROM backuppc
 
 EXPOSE 80
 VOLUME ["/etc/backuppc"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN htpasswd -b /etc/backuppc/htpasswd backuppc password
 COPY supervisord.conf /etc/supervisord.conf
 COPY msmtprc /var/lib/backuppc/.msmtprc
 COPY run.sh /run.sh
+COPY ssh-config /etc/backuppc-ssh-config
 
 RUN sed -i 's/\/usr\/sbin\/sendmail/\/usr\/bin\/msmtp/g' /etc/backuppc/config.pl
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@
 * change backuppc htaccess password in Dockerfile line 19 (or you may
   change it in the mapped configuration volume)
 
-## Build the container
+## SSH Keys
+If you use ```rsync``` based backup, an SSH key is generated for you.
+You can configure any backup target to accept this key
+
+## Build and run the container
 * cd into the directory
 * run ```docker build```
 * run the image ```docker run -d -P -v /<your-backup-folder>:/var/lib/backuppc -v /conf-dir:/etc/backuppc <image-id>```
@@ -21,3 +25,5 @@ This image declares /var/lib/backuppc and /etc/backuppc as volumes.
 You SHOULD map /var/lib/backuppc to a host volume (this will contain
 your backups).  You MAY map /etc/backuppc to a location to preserve
 configuration if you re-create your docker container.
+
+

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 # How to use
 ## Configure Mail
-* change the smtp host in msmtprc
+* You can use environment variables MAILHOST and FROM to set the target
+mail relay host and mail "from" address, respectively.
 
 ## Configure user credentials
 * change backuppc htaccess password in Dockerfile line 19 (or you may
@@ -25,5 +26,7 @@ This image declares /var/lib/backuppc and /etc/backuppc as volumes.
 You SHOULD map /var/lib/backuppc to a host volume (this will contain
 your backups).  You MAY map /etc/backuppc to a location to preserve
 configuration if you re-create your docker container.
+
+
 
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,23 @@
 # Summary
-* BackupPC based on Ubuntu 14.04
+* [BackupPC](http://backuppc.sourceforge.net/) based on Ubuntu 14.04
 * Support for sending status mail using msmtp
 
 # How to use
+## Configure Mail
 * change the smtp host in msmtprc
-# change backuppc htaccess password in Dockerfile line 19
+
+## Configure user credentials
+* change backuppc htaccess password in Dockerfile line 19 (or you may
+  change it in the mapped configuration volume)
+
+## Build the container
 * cd into the directory
 * run ```docker build```
-* run the image ```docker run -d -P -v /<your-backup-folder>:/var/lib/backuppc <image-id>```
+* run the image ```docker run -d -P -v /<your-backup-folder>:/var/lib/backuppc -v /conf-dir:/etc/backuppc <image-id>```
+
+# Volume Use
+
+This image declares /var/lib/backuppc and /etc/backuppc as volumes.
+You SHOULD map /var/lib/backuppc to a host volume (this will contain
+your backups).  You MAY map /etc/backuppc to a location to preserve
+configuration if you re-create your docker container.

--- a/msmtprc
+++ b/msmtprc
@@ -2,5 +2,5 @@ account default
 logfile ~/.msmtp.log
 tls off
 auth off
-host 172.17.42.1
-from backuppc
+host MAILHOST
+from FROM

--- a/run.sh
+++ b/run.sh
@@ -9,5 +9,12 @@ then
 	echo 1 > /firstrun
 fi
 
+# If there is no config (for example, because this volume is newly
+# mapped on the host), create the default configuration
+
+if [ ! -e /etc/backuppc/config.pl ] ; then
+    tar -f /root/etc-backuppc.tgz -xC /etc/backuppc
+fi
+
 exec /usr/local/bin/supervisord -c /etc/supervisord.conf
 

--- a/run.sh
+++ b/run.sh
@@ -16,5 +16,22 @@ if [ ! -e /etc/backuppc/config.pl ] ; then
     tar -f /root/etc-backuppc.tgz -xC /etc/backuppc
 fi
 
+# Ensure that an SSH key exists
+if [ ! -e /var/lib/backuppc/.ssh/id_rsa ] ; then
+    mkdir /var/lib/backuppc/.ssh
+    ssh-keygen -f /var/lib/backuppc/.ssh/id_rsa -C "BackupPC Backup Key"
+    cp /etc/backuppc-ssh-config /var/lib/backuppc/.ssh/config
+    chown -R backuppc:backuppc /var/lib/backuppc/.ssh
+    echo 
+    echo ======================================================================
+    echo 
+    echo "Use this SSH Key for backup:"
+    echo 
+    cat /var/lib/backuppc/.ssh/id_rsa.pub
+    echo
+    echo ======================================================================
+    echo 
+fi
+
 exec /usr/local/bin/supervisord -c /etc/supervisord.conf
 

--- a/run.sh
+++ b/run.sh
@@ -33,5 +33,11 @@ if [ ! -e /var/lib/backuppc/.ssh/id_rsa ] ; then
     echo 
 fi
 
+# Ensure that the mail host is configured properly from the
+# environment variables.  Do this each time to allow mail
+# configuration to change by simply recreating the container.
+
+sed -e "s/MAILHOST/$MAILHOST/g" -e "s/FROM/$FROM/g" /var/lib/backuppc/.msmtprc.dist > /var/lib/backuppc/.msmtprc
+
 exec /usr/local/bin/supervisord -c /etc/supervisord.conf
 

--- a/ssh-config
+++ b/ssh-config
@@ -1,0 +1,1 @@
+StrictHostKeyChecking no


### PR DESCRIPTION
Thanks for this base!  I made a number of changes:

* create /etc/backuppc as a volume and handle initial population when it's mapped to a host directory
* configure mail sending by environment variables
* generate an SSH key for use in backup.

If you'd prefer, I can give you these changes as separate PRs.